### PR TITLE
Skip 'ntpdate' dependency for RHEL packages

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -113,7 +113,7 @@ tracks:
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc} --os-name fedora
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
-      :{release_inc} --os-name rhel
+      :{release_inc} --os-name rhel --skip-keys ntpdate
     devel_branch: ros2
     last_version: 3.1.0
     name: diagnostics
@@ -139,7 +139,7 @@ tracks:
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc} --os-name fedora
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
-      :{release_inc} --os-name rhel
+      :{release_inc} --os-name rhel --skip-keys ntpdate
     devel_branch: ros2
     last_version: 3.1.0
     name: diagnostics


### PR DESCRIPTION
Hello diagnostics maintainers (@ralph-lange @bricerebsamen @trainman419) -

In order to prevent the packages in this repository from regressing on RHEL, we need to make some changes to omit the affected packages from the release pipeline so that the other unaffected packages can continue to build.

This involves two changes:
1. Skip the missing rosdep key during RHEL generation here, which will allow all of the packages to be released.
2. Block the buildfarm from attempting to build the package(s) which now have unsatisfied dependencies.

The only ongoing cost of this change is that future releases of this package will get a prompt about a custom action list and whether it should be changed back to the default. Please take the default value at the prompt, which will maintain the special addition here.

Once you've moved to a new package (ros/diagnostics#253), we can revert this change and subsequent releases will proceed normally.

To resolve the currently active release, I will retroactively perform the RHEL generation so that a re-release of the package isn't necessary. All that we require to move forward is your acknowledgement here.